### PR TITLE
Fix download state bug

### DIFF
--- a/borderlands/media.py
+++ b/borderlands/media.py
@@ -267,9 +267,7 @@ def evidence_source_handler(
             # Convert altered contexts back to a dataframe
             newly_downloaded = pl.from_dicts(contexts, schema=Media.schema())
             # Combine the downloaded and newly downloaded dataframes
-            results[Media.evidence_source.name] = pl.concat(
-                [downloaded, newly_downloaded]
-            )
+            results[evidence_source.value] = pl.concat([downloaded, newly_downloaded])
 
         if evidence_source.value in __evidence_handler_registery__:
             raise ValueError(


### PR DESCRIPTION
Downloaded files weren't properly persisted into the media inventory file as they were assigned to the wrong key in the results dictionary.