### PR TITLE
Update publish-docs.yml with permissions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,6 +11,11 @@ jobs:
     name: Build and publish docs
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
Permissions definition set to allow writes to branch.

```txt
/usr/bin/git push --force ***github.com/dominictarro/Borderlands.git github-pages-deploy-action/iu9wwtyrv:docs
remote: Permission to dominictarro/Borderlands.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/dominictarro/Borderlands.git/': The requested URL returned error: 403
Running post deployment cleanup jobs… 🗑️
/usr/bin/git checkout -B github-pages-deploy-action/iu9wwtyrv
Reset branch 'github-pages-deploy-action/iu9wwtyrv'
/usr/bin/chmod -R +rw github-pages-deploy-action-temp-deployment-folder
/usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force
Error: The deploy step encountered an error: The process '/usr/bin/git' failed with exit code 128 ❌
```
