### PR TITLE
Remove Prefect task persistence and the bucket for it

### DIFF
--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -38,8 +38,6 @@ No modules.
 | [aws_iam_user.cicd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.prefect](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_s3_bucket.core_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.persistence_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_lifecycle_configuration.persistence_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -47,7 +45,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_s3_bucket_core"></a> [s3\_bucket\_core](#input\_s3\_bucket\_core) | Name of the S3 bucket to store Borderlands files. | `string` | `"borderlands-core"` | no |
-| <a name="input_s3_bucket_persistence"></a> [s3\_bucket\_persistence](#input\_s3\_bucket\_persistence) | Name of the S3 bucket to store Prefect persistence files. | `string` | `"borderlands-persistence"` | no |
 
 ## Outputs
 
@@ -55,7 +52,6 @@ No modules.
 |------|-------------|
 | <a name="output_borderlands_cicd_user_name"></a> [borderlands\_cicd\_user\_name](#output\_borderlands\_cicd\_user\_name) | Name of the Borderlands CI/CD AWS user. |
 | <a name="output_core_bucket_id"></a> [core\_bucket\_id](#output\_core\_bucket\_id) | ID of the S3 bucket to store Borderlands files. |
-| <a name="output_persistence_bucket_id"></a> [persistence\_bucket\_id](#output\_persistence\_bucket\_id) | ID of the S3 bucket to store Prefect persistence files. |
 | <a name="output_prefect_user_name"></a> [prefect\_user\_name](#output\_prefect\_user\_name) | Name of the Prefect AWS user. |
 <!-- END_TF_DOCS -->
 

--- a/infrastructure/terraform/s3.tf
+++ b/infrastructure/terraform/s3.tf
@@ -3,37 +3,6 @@ Borderlands S3 buckets configuration.
 */
 
 /*
-Persistence bucket for Prefect.
-*/
-
-variable "s3_bucket_persistence" {
-    type = string
-    description = "Name of the S3 bucket to store Prefect persistence files."
-    default = "borderlands-persistence"
-}
-
-resource "aws_s3_bucket" "persistence_bucket" {
-    bucket = var.s3_bucket_persistence
-}
-
-resource "aws_s3_bucket_lifecycle_configuration" "persistence_bucket" {
-    bucket = aws_s3_bucket.persistence_bucket.id
-
-    rule {
-        id = "Delete Old Persistence Files"
-        status = "Enabled"
-        noncurrent_version_expiration {
-            noncurrent_days = 10
-        }
-    }
-}
-
-output "persistence_bucket_id" {
-    value = aws_s3_bucket.persistence_bucket.id
-    description = "ID of the S3 bucket to store Prefect persistence files."
-}
-
-/*
 Core datasets and releases bucket.
 */
 

--- a/src/borderlands/blocks.py
+++ b/src/borderlands/blocks.py
@@ -14,7 +14,6 @@ class Blocks:
     """Class for lazy loading Prefect Blocks."""
 
     _core_bucket: S3Bucket | None = None
-    _persistence_bucket: S3Bucket | None = None
     _oryx_bucket: S3Bucket | None = None
     _assets_bucket: S3Bucket | None = None
     _media_bucket: S3Bucket | None = None
@@ -26,15 +25,6 @@ class Blocks:
         if not self._core_bucket:
             self._core_bucket = S3Bucket.load("s3-bucket-borderlands-core")
         return self._core_bucket
-
-    @property
-    def persistence_bucket(self) -> S3Bucket:
-        """Returns the bucket for the program. Loads if it isn't already."""
-        if not self._persistence_bucket:
-            self._persistence_bucket = S3Bucket.load(
-                "s3-bucket-borderlands-persistence"
-            )
-        return self._persistence_bucket
 
     @property
     def webhook(self) -> SlackWebhook:
@@ -71,12 +61,6 @@ class Blocks:
             (await self.core_bucket)
             if asyncio.iscoroutine(self.core_bucket)
             else self.core_bucket
-        )
-
-        self._persistence_bucket = (
-            (await self.persistence_bucket)
-            if asyncio.iscoroutine(self.persistence_bucket)
-            else self.persistence_bucket
         )
 
         self._webhook = (

--- a/src/borderlands/cli/blocks.py
+++ b/src/borderlands/cli/blocks.py
@@ -101,41 +101,6 @@ def bucket_core(bucket_name: str, credentials: str, block_name: str):
 
 @blocks.command()
 @click.option(
-    "-n",
-    "--bucket-name",
-    type=str,
-    default="borderlands-persistence",
-    help="The name of the S3 bucket.",
-)
-@click.option(
-    "-c",
-    "--credentials",
-    type=str,
-    default="aws-credentials-prefect",
-    help="The name of the AWS credentials block.",
-)
-@click.option(
-    "-b",
-    "--block-name",
-    type=str,
-    default="s3-bucket-borderlands-persistence",
-    help="The name of the block.",
-)
-def bucket_persistence(bucket_name: str, credentials: str, block_name: str):
-    """Create the S3 Bucket block for the persistence bucket."""
-    from prefect_aws import AwsCredentials, S3Bucket
-
-    aws_credentials = AwsCredentials.load(credentials)
-    persistence_bucket = S3Bucket(
-        _block_document_name=block_name,
-        bucket_name=bucket_name,
-        credentials=aws_credentials,
-    )
-    save(persistence_bucket)
-
-
-@blocks.command()
-@click.option(
     "-t",
     "--tag",
     type=str,


### PR DESCRIPTION
Closes #50

Changes in recent Prefect versions appear to break my application of a persistence bucket. It was low-value for the pipeline anyway and should be removed.

- Removed all cases of task persistence
- Removed all cases of the persistence S3 bucket block (including tests and CLI)
- Removed the persistence bucket from Terraform